### PR TITLE
Docker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .*
+*.iml
+.idea/

--- a/Dockerfile.owb
+++ b/Dockerfile.owb
@@ -5,4 +5,4 @@ WORKDIR /workdir
 COPY pom.xml .
 COPY src .
 
-CMD [ "mvn", "verify", "-Popenwebbeans" ]
+CMD [ "mvn", "package", "-Popenwebbeans" ]

--- a/Dockerfile.owb
+++ b/Dockerfile.owb
@@ -1,4 +1,4 @@
-FROM maven:3.6-openjdk-8
+FROM maven:3.6-openjdk-11-slim
 
 WORKDIR /workdir
 

--- a/Dockerfile.owb
+++ b/Dockerfile.owb
@@ -1,0 +1,8 @@
+FROM maven:3.6-openjdk-8
+
+WORKDIR /workdir
+
+COPY pom.xml .
+COPY src .
+
+CMD [ "mvn", "verify", "-Popenwebbeans" ]

--- a/Dockerfile.weld
+++ b/Dockerfile.weld
@@ -1,0 +1,8 @@
+FROM maven:3.6-openjdk-8
+
+WORKDIR /workdir
+
+COPY pom.xml .
+COPY src .
+
+CMD [ "mvn", "verify", "-Pweld" ]

--- a/Dockerfile.weld
+++ b/Dockerfile.weld
@@ -5,4 +5,4 @@ WORKDIR /workdir
 COPY pom.xml .
 COPY src .
 
-CMD [ "mvn", "verify", "-Pweld" ]
+CMD [ "mvn", "package", "-Pweld" ]

--- a/Dockerfile.weld
+++ b/Dockerfile.weld
@@ -1,4 +1,4 @@
-FROM maven:3.6-openjdk-8
+FROM maven:3.6-openjdk-11-slim
 
 WORKDIR /workdir
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ $ mvn verify -Popenwebbeans
 $ mvn verify -Pweld
 ```
 
+To avoid issues with the maven-gpg-plugin, you can use `package` instead:
+
+```
+$ mvn package -Popenwebbeans
+$ mvn package -Pweld
+```
+
 #### Via Docker
 
 To run the tests using Docker build the containers and run them:

--- a/README.md
+++ b/README.md
@@ -4,4 +4,36 @@
 # MicroJPA
 
 MicroJPA is a framework to provide injection of resource-local ``EntityManager``s and their factories via ``@PersistenceContext`` and ``@PersistenceUnit`` in CDI-environments where no such injection is present.
-That may be the case in testing scenarios or with servers that do not implement the full JEE stack like [Meecrowave](https://openwebbeans.apache.org/meecrowave/).  
+That may be the case in testing scenarios or with servers that do not implement the full JEE stack like [Meecrowave](https://openwebbeans.apache.org/meecrowave/).
+
+## Build
+
+### Requirements
+
+In order to build the library _GPG_ and _Maven_ are required.
+ * https://maven.apache.org/download.cgi
+ * https://gnupg.org/download/index.html
+
+GPG is required in the _verify_ step to sign the package. It can be disabled for local development via `-Pdisable-gpg` command line parameter.  
+
+### Run tests
+
+#### Local
+
+To run the tests locally run:
+
+```
+$ mvn verify -Popenwebbeans
+$ mvn verify -Pweld
+```
+
+#### Via Docker
+
+To run the tests using Docker build the containers and run them:
+
+```
+$ docker build -t microjpa-owb -f Dockerfile.owb .
+$ docker build -t microjpa-weld -f Dockerfile.weld .
+$ docker run --rm microjpa-owb
+$ docker run --rm microjpa-weld
+```


### PR DESCRIPTION
Adds Dockerfiles for openwebbeans and weld to run the tests. For now we only use `package` to avoid issues with the gpg-plugin.